### PR TITLE
fix mormor-dump exe

### DIFF
--- a/exe/mormor-dump
+++ b/exe/mormor-dump
@@ -4,4 +4,4 @@ require_relative '../lib/mormor'
 path = ARGV.shift or abort "Usage: mormor-dump <dictionary>.dict"
 File.exist?(path) or abort "#{path} does not exist"
 
-MorMor::FSA.new(path).each_sequence(&method(:puts))
+MorMor::FSA.read(path).each_sequence(&method(:puts))


### PR DESCRIPTION
MorMor::FSA has no proper initializer.

```
exe/mormor-dump:7:in `initialize': wrong number of arguments (given 1, expected 0) (ArgumentError)
```